### PR TITLE
Bump dependency bounds

### DIFF
--- a/wkt.cabal
+++ b/wkt.cabal
@@ -23,10 +23,10 @@ source-repository head
 library
   exposed-modules:     Data.Geo.WKT, Data.Geo.WKT.Types, Data.Geo.WKT.Parser
   other-extensions:    TemplateHaskell
-  build-depends:       base >=4.6 && <4.11,
-                       lens >=3.9 && <4.16,
+  build-depends:       base >=4.6 && <4.12,
+                       lens >=3.9 && <4.18,
                        linear >=1.3 && <1.21,
-                       trifecta >=1.5 && <1.8
+                       trifecta >=1.5 && <2.1
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -39,6 +39,6 @@ test-suite tests
                        lens,
                        linear,
                        trifecta,
-                       tasty >= 0.11 && < 1.0,
+                       tasty >= 0.11 && < 1.2,
                        tasty-golden >= 2.3 && < 3.0,
                        wkt


### PR DESCRIPTION
The package still builds and passes tests with these changes. With this, `cabal outdated` indicates all dependencies are up to date.